### PR TITLE
fix: correct deploy-pages and auto-merge workflows

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -2,11 +2,7 @@
 name: Auto Merge
 on:
   pull_request:
-  workflow_run:
-    workflows: ["Validate Skills"]
-    types: [completed]
-  push:
-    branches: [main]
+    types: [opened, synchronize, reopened]
 
 jobs:
   auto-merge:
@@ -21,3 +17,5 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           MERGE_METHOD: squash
           AUTO_MERGE_METHOD: squash
+          UPDATE_METHOD: merge
+          MAX_RETRY: 5

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -21,10 +21,23 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
       - uses: actions/setup-python@v5
         with:
           python-version: '3.12'
-      - run: pip install mkdocs mkdocs-material
-      - run: mkdocs gh-deploy --force
+
+      - name: Configure git for gh-deploy
+        run: |
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git remote set-url origin https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/clowlove/Harmes-House.git
+
+      - name: Install and deploy
+        run: |
+          pip install mkdocs mkdocs-material
+          mkdocs gh-deploy --force --message "Auto deploy $(date)"
+
       - id: deployment
         uses: actions/deploy-pages@v4


### PR DESCRIPTION
Fix deploy-pages to use x-access-token for gh-deploy auth. Simplify auto-merge to only run on PR events.