### PR TITLE
fix: exit 0 instead of 1 when no changes to commit

### DIFF
--- a/.github/workflows/hermes-journal.yml
+++ b/.github/workflows/hermes-journal.yml
@@ -115,7 +115,7 @@ jobs:
           git add -A
           if git diff --staged --quiet; then
             echo "No changes to commit"
-            exit 1
+            exit 0
           fi
           git commit -m "Auto-update journal"
           git push -u origin "$BRANCH"
@@ -185,7 +185,7 @@ jobs:
           git add hermes-journal.md
           if git diff --staged --quiet; then
             echo "No changes to commit"
-            exit 1
+            exit 0
           fi
           git commit -m "Weekly summary update"
           git push -u origin "$BRANCH"


### PR DESCRIPTION
Fix CI failure when workflow runs but has no changes to commit. Changed exit 1 to exit 0 in hermes-journal.yml for both update-journal and weekly-reflection jobs.

**Root cause**: The 'Create Branch and Commit' step in weekly-reflection exits with code 1 when there are no changes to commit. This causes the step to fail even though there's nothing wrong - just no content to update.

**Fix**: Exit with 0 instead of 1 when there are no changes, as this is normal behavior.