### PR TITLE
feat: add tiered Harmes-House skill installer

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,13 @@
+# Hermes House environment template
+# Copy this file to .env and fill in the secrets you actually use.
+
+# Required for the docs' default integrations
+ANTHROPIC_API_KEY=
+TELEGRAM_BOT_TOKEN=
+GITHUB_TOKEN=
+
+# Optional integrations mentioned across the repo
+OPENROUTER_API_KEY=
+MINIMAX_API_KEY=
+NVIDIA_API_KEY=
+HF_TOKEN=

--- a/README.md
+++ b/README.md
@@ -53,7 +53,11 @@ Persistent, layered memory architecture:
 | L3 | Semantic | Knowledge | Long-term |
 
 ### 🛠️ Modular Skills Library
-**63+ pre-built skills** ready to use:
+**101 pre-built skills** with tiered installation:
+
+- `--core` — 32 A-tier core skills
+- `--standard` — 78 A+B recommended skills (default)
+- `--full` — all 101 skills, including specialized/personal C-tier skills
 
 | Category | Skills |
 |----------|--------|
@@ -115,48 +119,58 @@ Persistent, layered memory architecture:
 ## 🚀 Quick Start
 
 ### Prerequisites
-- Node.js 22.x or higher
-- npm 10.x or higher
-- Telegram account (for bot integration)
-- GitHub account (for automation)
+- Hermes Agent CLI installed
+- Git + Bash
+- Telegram account (optional, for bot integration)
+- GitHub account / PAT (optional, for automation)
+- Node.js 22.x only if you plan to run the `projects/*` sub-projects
 
 ### Installation
 
 ```bash
-# Clone the repository
+# 1) Install Hermes Agent core first
+curl -fsSL https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.sh | bash
+
+# 2) Clone the Harmes-House skill/evolution hub
 git clone https://github.com/clowlove/Harmes-House.git
 cd Harmes-House
 
-# Explore available skills
-ls skills/
+# 3) Install the recommended A+B skill pack into the active Hermes home
+bash scripts/install.sh
 
-# View AI growth journal
-cat hermes-journal.md
+# Optional install modes:
+# bash scripts/install.sh --core      # 32 core skills
+# bash scripts/install.sh --standard  # 78 recommended skills (default)
+# bash scripts/install.sh --full      # all 101 skills
+
+# 4) Verify
+hermes skills list
 ```
 
 ### Configuration
 
 ```bash
-# Copy environment template
+# Copy environment template when using Telegram / GitHub integrations
 cp .env.example .env
 
 # Edit with your API keys
 nano .env
 ```
 
-Required environment variables:
+Common environment variables:
 - `ANTHROPIC_API_KEY` — Claude API key
-- `TELEGRAM_BOT_TOKEN` — Telegram bot token  
+- `TELEGRAM_BOT_TOKEN` — Telegram bot token
 - `GITHUB_TOKEN` — GitHub Personal Access Token
+- `OPENROUTER_API_KEY` / `MINIMAX_API_KEY` — optional model providers
 
 ### Running
 
 ```bash
-# Development mode
-npm run dev
+# Start Hermes normally
+hermes
 
-# Production mode
-npm start
+# Or preload one or more installed skills
+hermes -s hermes-agent,github-pr-workflow
 ```
 
 ---
@@ -168,11 +182,11 @@ Harmes-House/
 ├── AGENTS.md              # AI identity definition
 ├── hermes-journal.md      # AI self-recorded growth journal
 │
-├── skills/                # 63+ modular skills
+├── skills/                # 101 modular skills
 │   ├── trendradar/        # News aggregation skill
 │   ├── github/            # GitHub automation
 │   ├── data-science/      # Data analysis tools
-│   └── ...                # 60+ more skills
+│   └── ...                # more skills
 │
 ├── docs/                  # Documentation
 │   ├── architecture/     # System architecture
@@ -203,7 +217,7 @@ Harmes-House/
 Latest entries from [hermes-journal.md](hermes-journal.md):
 
 <!-- JOURNAL_PREVIEW -->
-- **2026-05-17** — Skill library expanded to 63+ skills
+- **2026-05-17** — Skill library expanded to 101 skills
 - **2026-05-15** — GitHub monetization infrastructure deployed
 - **2026-05-12** — Self-improvement engine v2 complete
 - **2026-05-10** — Documentation site launched
@@ -215,7 +229,7 @@ Latest entries from [hermes-journal.md](hermes-journal.md):
 | Metric | Value |
 |--------|-------|
 | Days Running | 14+ |
-| Skills Available | 63+ |
+| Skills Available | 101 |
 | Git Commits | 200+ |
 | Sub-projects | 2 |
 | Code Review PRs | 20+ |
@@ -235,7 +249,7 @@ Latest entries from [hermes-journal.md](hermes-journal.md):
 | `huggingface` | Model Hub integration | ML/AI |
 | `telegram` | Bot commands & notifications | Automation |
 
-**[View all 63+ skills →](docs/skills.md)**
+**[View skills →](docs/skills.md)** — full tier audit: [docs/SKILLS_AUDIT.md](docs/SKILLS_AUDIT.md)
 
 ---
 

--- a/docs/SKILLS_AUDIT.md
+++ b/docs/SKILLS_AUDIT.md
@@ -1,0 +1,334 @@
+# Harmes-House Skills Audit
+
+目的：把 `skills/` 下 101 个 Hermes skill 分成三档，避免“全装但多数不用”的噪音。
+
+## 结论
+
+- 总数：**101**
+- **必留 A**：32 个 — 通用、高频、推荐保留
+- **可选 B**：46 个 — 有用，但依赖账号/API/MCP/具体任务
+- **不默认启用 C**：23 个 — 强场景限定、个人化、娱乐展示或当前环境不匹配
+
+建议：不要把 101 个都当“核心能力”。保留 A；B 按需求装；C 只在明确需要时再加载/迁入。
+
+## 重大问题：技能重名
+
+这些 Harmes-House 技能和当前 Hermes 已有技能重名，裸用 `/skill name` 或 `skill_view(name)` 可能报 `Ambiguous skill name`。应使用 `harmes-house/<name>` 或清理重复。
+
+| skill | 已存在路径 | Harmes-House 路径 |
+|---|---|---|
+| `airtable` | `productivity/airtable/SKILL.md` | `harmes-house/airtable/SKILL.md` |
+| `apple-notes` | `apple/apple-notes/SKILL.md` | `harmes-house/apple-notes/SKILL.md` |
+| `apple-reminders` | `apple/apple-reminders/SKILL.md` | `harmes-house/apple-reminders/SKILL.md` |
+| `architecture-diagram` | `creative/architecture-diagram/SKILL.md` | `harmes-house/architecture-diagram/SKILL.md` |
+| `arxiv` | `research/arxiv/SKILL.md` | `harmes-house/arxiv/SKILL.md` |
+| `ascii-art` | `creative/ascii-art/SKILL.md` | `harmes-house/ascii-art/SKILL.md` |
+| `ascii-video` | `creative/ascii-video/SKILL.md` | `harmes-house/ascii-video/SKILL.md` |
+| `baoyu-comic` | `creative/baoyu-comic/SKILL.md` | `harmes-house/baoyu-comic/SKILL.md` |
+| `baoyu-infographic` | `creative/baoyu-infographic/SKILL.md` | `harmes-house/baoyu-infographic/SKILL.md` |
+| `blogwatcher` | `research/blogwatcher/SKILL.md` | `harmes-house/blogwatcher/SKILL.md` |
+| `claude-code` | `autonomous-ai-agents/claude-code/SKILL.md` | `harmes-house/claude-code/SKILL.md` |
+| `claude-design` | `creative/claude-design/SKILL.md` | `harmes-house/claude-design/SKILL.md` |
+| `codebase-inspection` | `github/codebase-inspection/SKILL.md` | `harmes-house/codebase-inspection/SKILL.md` |
+| `codex` | `autonomous-ai-agents/codex/SKILL.md` | `harmes-house/codex/SKILL.md` |
+| `comfyui` | `creative/comfyui/SKILL.md` | `harmes-house/comfyui/SKILL.md` |
+| `creative-ideation` | `creative/creative-ideation/SKILL.md` | `harmes-house/creative-ideation/SKILL.md` |
+| `debugging-hermes-tui-commands` | `software-development/debugging-hermes-tui-commands/SKILL.md` | `harmes-house/debugging-hermes-tui-commands/SKILL.md` |
+| `design-md` | `creative/design-md/SKILL.md` | `harmes-house/design-md/SKILL.md` |
+| `excalidraw` | `creative/excalidraw/SKILL.md` | `harmes-house/excalidraw/SKILL.md` |
+| `findmy` | `apple/findmy/SKILL.md` | `harmes-house/findmy/SKILL.md` |
+| `gif-search` | `media/gif-search/SKILL.md` | `harmes-house/gif-search/SKILL.md` |
+| `github-auth` | `github/github-auth/SKILL.md` | `harmes-house/github-auth/SKILL.md` |
+| `github-code-review` | `github/github-code-review/SKILL.md` | `harmes-house/github-code-review/SKILL.md` |
+| `github-issues` | `github/github-issues/SKILL.md` | `harmes-house/github-issues/SKILL.md` |
+| `github-pr-workflow` | `github/github-pr-workflow/SKILL.md` | `harmes-house/github-pr-workflow/SKILL.md` |
+| `github-repo-management` | `github/github-repo-management/SKILL.md` | `harmes-house/github-repo-management/SKILL.md` |
+| `godmode` | `red-teaming/godmode/SKILL.md` | `harmes-house/godmode/SKILL.md` |
+| `google-workspace` | `productivity/google-workspace/SKILL.md` | `harmes-house/google-workspace/SKILL.md` |
+| `heartmula` | `media/heartmula/SKILL.md` | `harmes-house/heartmula/SKILL.md` |
+| `hermes-agent` | `autonomous-ai-agents/hermes-agent/SKILL.md` | `harmes-house/hermes-agent/SKILL.md` |
+| `hermes-agent-skill-authoring` | `software-development/hermes-agent-skill-authoring/SKILL.md` | `harmes-house/hermes-agent-skill-authoring/SKILL.md` |
+| `himalaya` | `email/himalaya/SKILL.md` | `harmes-house/himalaya/SKILL.md` |
+| `huggingface-hub` | `mlops/huggingface-hub/SKILL.md` | `harmes-house/huggingface-hub/SKILL.md` |
+| `humanizer` | `creative/humanizer/SKILL.md` | `harmes-house/humanizer/SKILL.md` |
+| `imessage` | `apple/imessage/SKILL.md` | `harmes-house/imessage/SKILL.md` |
+| `jupyter-live-kernel` | `data-science/jupyter-live-kernel/SKILL.md` | `harmes-house/jupyter-live-kernel/SKILL.md` |
+| `kanban-orchestrator` | `devops/kanban-orchestrator/SKILL.md` | `harmes-house/kanban-orchestrator/SKILL.md` |
+| `kanban-worker` | `devops/kanban-worker/SKILL.md` | `harmes-house/kanban-worker/SKILL.md` |
+| `linear` | `productivity/linear/SKILL.md` | `harmes-house/linear/SKILL.md` |
+| `llm-wiki` | `research/llm-wiki/SKILL.md` | `harmes-house/llm-wiki/SKILL.md` |
+| `manim-video` | `creative/manim-video/SKILL.md` | `harmes-house/manim-video/SKILL.md` |
+| `maps` | `productivity/maps/SKILL.md` | `harmes-house/maps/SKILL.md` |
+| `minecraft-modpack-server` | `gaming/minecraft-modpack-server/SKILL.md` | `harmes-house/minecraft-modpack-server/SKILL.md` |
+| `nano-pdf` | `productivity/nano-pdf/SKILL.md` | `harmes-house/nano-pdf/SKILL.md` |
+| `native-mcp` | `mcp/native-mcp/SKILL.md` | `harmes-house/native-mcp/SKILL.md` |
+| `node-inspect-debugger` | `software-development/node-inspect-debugger/SKILL.md` | `harmes-house/node-inspect-debugger/SKILL.md` |
+| `notion` | `productivity/notion/SKILL.md` | `harmes-house/notion/SKILL.md` |
+| `obsidian` | `note-taking/obsidian/SKILL.md` | `harmes-house/obsidian/SKILL.md` |
+| `ocr-and-documents` | `productivity/ocr-and-documents/SKILL.md` | `harmes-house/ocr-and-documents/SKILL.md` |
+| `opencode` | `autonomous-ai-agents/opencode/SKILL.md` | `harmes-house/opencode/SKILL.md` |
+| `openhue` | `smart-home/openhue/SKILL.md` | `harmes-house/openhue/SKILL.md` |
+| `p5js` | `creative/p5js/SKILL.md` | `harmes-house/p5js/SKILL.md` |
+| `pixel-art` | `creative/pixel-art/SKILL.md` | `harmes-house/pixel-art/SKILL.md` |
+| `plan` | `software-development/plan/SKILL.md` | `harmes-house/plan/SKILL.md` |
+| `pokemon-player` | `gaming/pokemon-player/SKILL.md` | `harmes-house/pokemon-player/SKILL.md` |
+| `polymarket` | `research/polymarket/SKILL.md` | `harmes-house/polymarket/SKILL.md` |
+| `popular-web-designs` | `creative/popular-web-designs/SKILL.md` | `harmes-house/popular-web-designs/SKILL.md` |
+| `powerpoint` | `productivity/powerpoint/SKILL.md` | `harmes-house/powerpoint/SKILL.md` |
+| `pretext` | `creative/pretext/SKILL.md` | `harmes-house/pretext/SKILL.md` |
+| `python-debugpy` | `software-development/python-debugpy/SKILL.md` | `harmes-house/python-debugpy/SKILL.md` |
+| `requesting-code-review` | `software-development/requesting-code-review/SKILL.md` | `harmes-house/requesting-code-review/SKILL.md` |
+| `research-paper-writing` | `research/research-paper-writing/SKILL.md` | `harmes-house/research-paper-writing/SKILL.md` |
+| `sketch` | `creative/sketch/SKILL.md` | `harmes-house/sketch/SKILL.md` |
+| `songsee` | `media/songsee/SKILL.md` | `harmes-house/songsee/SKILL.md` |
+| `songwriting-and-ai-music` | `creative/songwriting-and-ai-music/SKILL.md` | `harmes-house/songwriting-and-ai-music/SKILL.md` |
+| `spike` | `software-development/spike/SKILL.md` | `harmes-house/spike/SKILL.md` |
+| `spotify` | `media/spotify/SKILL.md` | `harmes-house/spotify/SKILL.md` |
+| `subagent-driven-development` | `software-development/subagent-driven-development/SKILL.md` | `harmes-house/subagent-driven-development/SKILL.md` |
+| `systematic-debugging` | `software-development/systematic-debugging/SKILL.md` | `harmes-house/systematic-debugging/SKILL.md` |
+| `test-driven-development` | `software-development/test-driven-development/SKILL.md` | `harmes-house/test-driven-development/SKILL.md` |
+| `touchdesigner-mcp` | `creative/touchdesigner-mcp/SKILL.md` | `harmes-house/touchdesigner-mcp/SKILL.md` |
+| `webhook-subscriptions` | `devops/webhook-subscriptions/SKILL.md` | `harmes-house/webhook-subscriptions/SKILL.md` |
+| `writing-plans` | `software-development/writing-plans/SKILL.md` | `harmes-house/writing-plans/SKILL.md` |
+| `xurl` | `social-media/xurl/SKILL.md` | `harmes-house/xurl/SKILL.md` |
+| `youtube-content` | `media/youtube-content/SKILL.md` | `harmes-house/youtube-content/SKILL.md` |
+
+## 推荐动作
+
+1. **短期**：继续安装全量没问题，但使用时显式加载 `harmes-house/<skill>`，避免重名。
+2. **中期**：把 A 档复制到一个精简目录，例如 `$HERMES_HOME/skills/harmes-house-core/`。
+3. **长期**：把 C 档从默认安装脚本排除，改成 `--full` 或 `--extras` 才安装。
+
+## A 档：必留
+
+| skill | 用途 | 注意 |
+|---|---|---|
+| `claude-code` | Delegate coding to Claude Code CLI (features, PRs). | 凭证/API, MCP, GitHub |
+| `cli-utilities` | 实用 CLI 工具集 - HTTP 请求、JSON 处理、日期计算、文件转换等常用命令。快速执行，无需 Python 脚本。 | 凭证/API, macOS, GitHub |
+| `codebase-inspection` | Inspect codebases w/ pygount: LOC, languages, ratios. | GitHub |
+| `codex` | Delegate coding to OpenAI Codex CLI (features, PRs). | GitHub |
+| `copilot-cli` | GitHub Copilot CLI — 安装、认证、三种模式、工具权限、上下文管理、GitHub 集成、Custom Agents、MCP、Hooks | 凭证/API, macOS, MCP, GitHub |
+| `custom-openai-provider` | Configure any OpenAI-compatible API as a Hermes model provider — NVIDIA NIM, Together AI, Fireworks, Groq, local vLLM/Ollama, or any custom endpoint. Covers the | 凭证/API, 网关/消息 |
+| `debugging-hermes-tui-commands` | Debug Hermes TUI slash commands: Python, gateway, Ink UI. | 网关/消息, GitHub |
+| `github-auth` | GitHub auth setup: HTTPS tokens, SSH keys, gh CLI login. | 凭证/API, 系统级, GitHub |
+| `github-code-review` | Review PRs: diffs, inline comments via gh or REST. | 凭证/API, GitHub |
+| `github-issues` | Create, triage, label, assign GitHub issues via gh or REST. | 凭证/API, GitHub |
+| `github-pages-site` | Build and deploy a static website (business landing page, portfolio, docs) to GitHub Pages. Covers repo creation, content deployment, and Pages enabling via Git | 凭证/API, GitHub |
+| `github-pr-workflow` | GitHub PR lifecycle: branch, commit, open, CI, merge. | 凭证/API, GitHub |
+| `github-repo-management` | Clone/create/fork repos; manage remotes, releases. | 凭证/API, GitHub |
+| `hermes-agent` | Configure, extend, or contribute to Hermes Agent. | 凭证/API, macOS, MCP, 网关/消息, 系统级, GitHub |
+| `hermes-agent-skill-authoring` | Author in-repo SKILL.md: frontmatter, validator, structure. | 凭证/API, GitHub |
+| `hermes-telegram-setup` | Set up and troubleshoot Telegram bot integration with Hermes Agent gateway — token config, pairing flow, gateway service management, and common pitfalls. | 凭证/API, 网关/消息, GitHub |
+| `matplotlib-charts` | 使用 matplotlib 生成图表 - 趋势图、柱状图、饼图、热力图等。导出 PNG/SVG/PDF，用于报告和可视化。 | 凭证/API, macOS, GitHub |
+| `model-fallback` | 为 Hermes Agent 配置模型故障转移，自动切换到备用模型。类似于 FreeRide 的"速率限制自动切换"概念，但专为 Hermes Agent 设计。 | 凭证/API, macOS, GitHub |
+| `native-mcp` | MCP client: connect servers, register tools (stdio/HTTP). | 凭证/API, MCP, 网关/消息, GitHub |
+| `node-inspect-debugger` | Debug Node.js via --inspect + Chrome DevTools Protocol CLI. | 网关/消息, GitHub |
+| `opencode` | Delegate coding to OpenCode CLI (features, PR review). | 凭证/API, GitHub |
+| `plan` | Plan mode: write markdown plan to .hermes/plans/, no exec. | - |
+| `python-debugpy` | Debug Python: pdb REPL + debugpy remote (DAP). | 凭证/API, 网关/消息, 系统级, GitHub |
+| `report-generation` | 生成结构化报告 - Markdown/HTML/PDF 格式的聚合报告、趋势分析、数据摘要。支持定时生成和推送。 | 凭证/API, macOS, MCP, 网关/消息, GitHub |
+| `requesting-code-review` | Pre-commit review: security scan, quality gates, auto-fix. | 凭证/API, GitHub |
+| `spike` | Throwaway experiments to validate an idea before build. | 凭证/API, MCP, GitHub |
+| `sqlite-data` | SQLite 数据库操作 - 创建/查询/聚合 Hermes Agent 的结构化数据。存储新闻聚合、趋势数据、任务状态等。 | 凭证/API, macOS, GitHub |
+| `subagent-driven-development` | Execute plans via delegate_task subagents (2-stage review). | 凭证/API, GitHub |
+| `systematic-debugging` | 4-phase root cause debugging: understand bugs before fixing. | GitHub |
+| `test-driven-development` | TDD: enforce RED-GREEN-REFACTOR, tests before code. | GitHub |
+| `webhook-subscriptions` | Webhook subscriptions: event-driven agent runs. | 凭证/API, 网关/消息, 系统级, GitHub |
+| `writing-plans` | Write implementation plans: bite-sized tasks, paths, code. | - |
+
+## B 档：可选
+
+| skill | 用途 | 启用条件/注意 |
+|---|---|---|
+| `airtable` | Airtable REST API via curl. Records CRUD, filters, upserts. | 凭证/API, MCP, GitHub |
+| `architecture-diagram` | Dark-themed SVG architecture/cloud/infra diagrams as HTML. | macOS, GitHub |
+| `arxiv` | Search arXiv papers by keyword, author, category, or ID. | GitHub |
+| `baoyu-comic` | Knowledge comics (知识漫画): educational, biography, tutorial. | 凭证/API, GitHub |
+| `baoyu-infographic` | Infographics: 21 layouts x 21 styles (信息图, 可视化). | 凭证/API, GitHub |
+| `blogwatcher` | Monitor blogs and RSS/Atom feeds via blogwatcher-cli tool. | macOS, 系统级, GitHub |
+| `claude-design` | Design one-off HTML artifacts (landing, deck, prototype). | 凭证/API, GitHub |
+| `comfyui` | Generate images, video, and audio with ComfyUI — install, launch, manage nodes/models, run workflows with parameter injection. Uses the official comfy-cli for l | 凭证/API, macOS, 网关/消息, GitHub |
+| `design-md` | Author/validate/export Google's DESIGN.md token spec files. | 凭证/API, GitHub |
+| `evaluation` | Model evaluation benchmarks, experiment tracking, data curation, tokenizers, and interpretability tools. | 凭证/API |
+| `excalidraw` | Hand-drawn Excalidraw JSON diagrams (arch, flow, seq). | - |
+| `github-trend-daily` | 发现 GitHub AI Agent 热点，生成小红书风格日报并推送到 Telegram | 网关/消息, GitHub |
+| `google-workspace` | Gmail, Calendar, Drive, Docs, Sheets via gws CLI or Python. | 凭证/API, 网关/消息, GitHub |
+| `himalaya` | Himalaya CLI: IMAP/SMTP email from terminal. | 凭证/API, macOS, GitHub |
+| `huggingface-hub` | HuggingFace hf CLI: search/download/upload models, datasets. | 凭证/API, GitHub |
+| `humanizer` | Humanize text: strip AI-isms and add real voice. | GitHub |
+| `inference` | Model serving, quantization (GGUF/GPTQ), structured output, inference optimization, and model surgery tools for deploying and running LLMs. | GitHub |
+| `jupyter-live-kernel` | Iterative Python via live Jupyter kernel (hamelnb). | 凭证/API, GitHub |
+| `linear` | Linear: manage issues, projects, teams via GraphQL + curl. | 凭证/API, MCP |
+| `llm-wiki` | Karpathy's LLM Wiki: build/query interlinked markdown KB. | 凭证/API, 系统级, GitHub |
+| `mails` | Email infrastructure for AI agents - send/receive emails via Mails.dev | 凭证/API |
+| `manim-video` | Manim CE animations: 3Blue1Brown math/algo videos. | macOS, GitHub |
+| `maps` | Geocode, POIs, routes, timezones via OpenStreetMap/OSRM. | 网关/消息 |
+| `models` | Specific model architectures and tools — image segmentation (SAM), audio generation (MusicGen), CLIP, Stable Diffusion, Whisper, LLaVA. | - |
+| `nano-pdf` | Edit PDF text/typos/titles via nano-pdf CLI (NL prompts). | - |
+| `notion` | Notion API via curl: pages, databases, blocks, search. | 凭证/API, GitHub |
+| `obsidian` | Read, search, and create notes in the Obsidian vault. 支持 Hermes-Wiki 知识库工作流。 | 凭证/API, GitHub |
+| `ocr-and-documents` | Extract text from PDFs/scans (pymupdf, marker-pdf). | GitHub |
+| `p5js` | p5.js sketches: gen art, shaders, interactive, 3D. | macOS, GitHub |
+| `polymarket` | Query Polymarket: markets, prices, orderbooks, history. | 凭证/API |
+| `popular-web-designs` | 54 real design systems (Stripe, Linear, Vercel) as HTML/CSS. | 凭证/API, macOS |
+| `powerpoint` | Create, read, edit .pptx decks, slides, notes, templates. | MCP, GitHub |
+| `pretext` | Use when building creative browser demos with @chenglou/pretext — DOM-free text layout for ASCII art, typographic flow around obstacles, text-as-geometry games, | macOS, GitHub |
+| `public-api-tools` | 来自 public-apis 项目的免费公共 API 工具集 — QR码、图标、截图、LaTeX公式渲染等 | GitHub |
+| `research` | ML research frameworks for building and optimizing AI systems with declarative programming. | - |
+| `research-paper-writing` | Write ML papers for NeurIPS/ICML/ICLR: design→submit. | 凭证/API, macOS, MCP, 系统级, GitHub |
+| `scrapling` | Scrapling - 自适应 Web 爬虫框架，支持反爬绕过、自动元素定位、MCP 集成。47k+ stars 的生产级爬虫库。 | 凭证/API, macOS, MCP, GitHub |
+| `seo-verify` | Search engine site verification (Google, Baidu, Bing) + sitemap optimization + domain binding workflow. Covers GitHub Pages, Windows shared hosting with FTP, an | 凭证/API, GitHub |
+| `sketch` | Throwaway HTML mockups: 2-3 design variants to compare. | 凭证/API, macOS, GitHub |
+| `training` | Fine-tuning, RLHF/DPO/GRPO training, distributed training frameworks, and optimization tools for training LLMs. | - |
+| `trendradar` | TrendRadar trend monitoring and Telegram push — trigger crawl, fetch news, categorize, send multi-message Telegram notifications, archive to Obsidian, sync to G | MCP, 网关/消息, GitHub |
+| `trendradar-daily` | TrendRadar 多平台热点监控日报生成与 Telegram 推送 | MCP, 网关/消息, GitHub |
+| `vector-databases` | Vector database tools and integrations for semantic search and RAG applications. | - |
+| `website-seo` | Domain binding, SSL setup, Cloudflare DNS, search engine submission, sitemap management, and Windows shared hosting FTP workflows | 凭证/API, 网关/消息, 系统级, GitHub |
+| `xurl` | X/Twitter via xurl CLI: post, search, DM, media, v2 API. | 凭证/API, macOS, 系统级, GitHub |
+| `youtube-content` | YouTube transcripts to summaries, threads, blogs. | GitHub |
+
+## C 档：不默认启用
+
+| skill | 原因 | 用途/描述 |
+|---|---|---|
+| `3x-ui` | 绑定某台 VPS/某个 3x-ui 面板，含固定端口/IP/默认账号痕迹；不适合通用安装。 | 3x-ui (MHSanaei/3x-ui) panel administration — a VLESS/Xray web management UI. Install, configure, manage nodes, reset password, and troubleshoot. Installed at / |
+| `apple-notes` | Apple Notes 专用，依赖 macOS 工具。 | Manage Apple Notes via memo CLI: create, search, edit. |
+| `apple-reminders` | Apple Reminders 专用，依赖 macOS 工具。 | Apple Reminders via remindctl: add, list, complete. |
+| `ascii-art` | 娱乐展示类，低频。 | ASCII art: pyfiglet, cowsay, boxes, image-to-ascii. |
+| `ascii-video` | 娱乐/媒体转换类，低频且依赖 ffmpeg。 | ASCII video: convert video/audio to colored ASCII MP4/GIF. |
+| `creative-ideation` | 创意发散类，低频。 | Generate project ideas via creative constraints. |
+| `findmy` | macOS/Apple 生态专用，Linux WebUI 环境基本不可用。 | Track Apple devices/AirTags via FindMy.app on macOS. |
+| `foreign-trade-operations` | 绑定拖拉机外贸站点、域名和本地路径；只适合原作者业务。 | >- |
+| `gif-search` | 轻量娱乐/社交素材类，可用但不该默认加载。 | Search/download GIFs from Tenor via curl + jq. |
+| `godmode` | 红队/越狱类，风险高，非日常生产技能；默认不启用。 | Jailbreak LLMs: Parseltongue, GODMODE, ULTRAPLINIAN. |
+| `heartmula` | 音乐生成服务专项，低频且依赖外部服务。 | HeartMuLa: Suno-like song generation from lyrics + tags. |
+| `imessage` | macOS/iMessage 专用，当前 Linux 环境不可用。 | Send and receive iMessages/SMS via the imsg CLI on macOS. |
+| `kanban-orchestrator` | 强场景限定、个人化、娱乐展示、当前环境不匹配或风险较高；不建议默认启用。 | Decomposition playbook + specialist-roster conventions + anti-temptation rules for an orchestrator profile routing work through Kanban. The "don't do the work y |
+| `kanban-worker` | 强场景限定、个人化、娱乐展示、当前环境不匹配或风险较高；不建议默认启用。 | Pitfalls, examples, and edge cases for Hermes Kanban workers. The lifecycle itself is auto-injected into every worker's system prompt as KANBAN_GUIDANCE (from a |
+| `minecraft-modpack-server` | 游戏服专项，只有开服时有用。 | Host modded Minecraft servers (CurseForge, Modrinth). |
+| `npm-publishing` | npm 发布专项；当前环境无 npm，默认不启用。 | 发布 npm 包到 npmjs.com。包含认证、权限、发布流程。 |
+| `openhue` | 需要 Philips Hue 家居设备，非通用。 | Control Philips Hue lights, scenes, rooms via OpenHue CLI. |
+| `pixel-art` | 创作类，只有生成像素画时有用。 | Pixel art w/ era palettes (NES, Game Boy, PICO-8). |
+| `pokemon-player` | 娱乐/实验专项，非生产工作流。 | Play Pokemon via headless emulator + RAM reads. |
+| `songsee` | 音频分析专项，低频。 | Audio spectrograms/features (mel, chroma, MFCC) via CLI. |
+| `songwriting-and-ai-music` | 创作类，只有做音乐时有用。 | Songwriting craft and Suno AI music prompts. |
+| `spotify` | 需要 Spotify 账号/API/设备，非通用。 | Spotify: play, search, queue, manage playlists and devices. |
+| `touchdesigner-mcp` | TouchDesigner 专用，依赖本机图形环境/MCP。 | Control a running TouchDesigner instance via twozero MCP — create operators, set parameters, wire connections, execute Python, build real-time visuals. 36 nativ |
+
+## 全量清单
+
+| skill | 分级 | 标记 | 说明 |
+|---|---|---|---|
+| `3x-ui` | C / 不默认启用 | 凭证/API, 系统级, GitHub, 专用 | 3x-ui (MHSanaei/3x-ui) panel administration — a VLESS/Xray web management UI. Install, configure, manage nodes, reset password, and troubleshoot. Installed at / |
+| `airtable` | B / 可选 | 凭证/API, MCP, GitHub | Airtable REST API via curl. Records CRUD, filters, upserts. |
+| `apple-notes` | C / 不默认启用 | macOS, 专用 | Manage Apple Notes via memo CLI: create, search, edit. |
+| `apple-reminders` | C / 不默认启用 | macOS, GitHub, 专用 | Apple Reminders via remindctl: add, list, complete. |
+| `architecture-diagram` | B / 可选 | macOS, GitHub | Dark-themed SVG architecture/cloud/infra diagrams as HTML. |
+| `arxiv` | B / 可选 | GitHub | Search arXiv papers by keyword, author, category, or ID. |
+| `ascii-art` | C / 不默认启用 | macOS, 系统级, GitHub, 专用 | ASCII art: pyfiglet, cowsay, boxes, image-to-ascii. |
+| `ascii-video` | C / 不默认启用 | macOS, GitHub, 专用 | ASCII video: convert video/audio to colored ASCII MP4/GIF. |
+| `baoyu-comic` | B / 可选 | 凭证/API, GitHub | Knowledge comics (知识漫画): educational, biography, tutorial. |
+| `baoyu-infographic` | B / 可选 | 凭证/API, GitHub | Infographics: 21 layouts x 21 styles (信息图, 可视化). |
+| `blogwatcher` | B / 可选 | macOS, 系统级, GitHub | Monitor blogs and RSS/Atom feeds via blogwatcher-cli tool. |
+| `claude-code` | A / 必留 | 凭证/API, MCP, GitHub | Delegate coding to Claude Code CLI (features, PRs). |
+| `claude-design` | B / 可选 | 凭证/API, GitHub | Design one-off HTML artifacts (landing, deck, prototype). |
+| `cli-utilities` | A / 必留 | 凭证/API, macOS, GitHub | 实用 CLI 工具集 - HTTP 请求、JSON 处理、日期计算、文件转换等常用命令。快速执行，无需 Python 脚本。 |
+| `codebase-inspection` | A / 必留 | GitHub | Inspect codebases w/ pygount: LOC, languages, ratios. |
+| `codex` | A / 必留 | GitHub | Delegate coding to OpenAI Codex CLI (features, PRs). |
+| `comfyui` | B / 可选 | 凭证/API, macOS, 网关/消息, GitHub | Generate images, video, and audio with ComfyUI — install, launch, manage nodes/models, run workflows with parameter injection. Uses the official comfy-cli for l |
+| `copilot-cli` | A / 必留 | 凭证/API, macOS, MCP, GitHub | GitHub Copilot CLI — 安装、认证、三种模式、工具权限、上下文管理、GitHub 集成、Custom Agents、MCP、Hooks |
+| `creative-ideation` | C / 不默认启用 | GitHub, 专用 | Generate project ideas via creative constraints. |
+| `custom-openai-provider` | A / 必留 | 凭证/API, 网关/消息 | Configure any OpenAI-compatible API as a Hermes model provider — NVIDIA NIM, Together AI, Fireworks, Groq, local vLLM/Ollama, or any custom endpoint. Covers the |
+| `debugging-hermes-tui-commands` | A / 必留 | 网关/消息, GitHub | Debug Hermes TUI slash commands: Python, gateway, Ink UI. |
+| `design-md` | B / 可选 | 凭证/API, GitHub | Author/validate/export Google's DESIGN.md token spec files. |
+| `evaluation` | B / 可选 | 凭证/API | Model evaluation benchmarks, experiment tracking, data curation, tokenizers, and interpretability tools. |
+| `excalidraw` | B / 可选 | - | Hand-drawn Excalidraw JSON diagrams (arch, flow, seq). |
+| `findmy` | C / 不默认启用 | macOS, 专用 | Track Apple devices/AirTags via FindMy.app on macOS. |
+| `foreign-trade-operations` | C / 不默认启用 | GitHub, 专用 | >- |
+| `gif-search` | C / 不默认启用 | 凭证/API, macOS, 专用 | Search/download GIFs from Tenor via curl + jq. |
+| `github-auth` | A / 必留 | 凭证/API, 系统级, GitHub | GitHub auth setup: HTTPS tokens, SSH keys, gh CLI login. |
+| `github-code-review` | A / 必留 | 凭证/API, GitHub | Review PRs: diffs, inline comments via gh or REST. |
+| `github-issues` | A / 必留 | 凭证/API, GitHub | Create, triage, label, assign GitHub issues via gh or REST. |
+| `github-pages-site` | A / 必留 | 凭证/API, GitHub | Build and deploy a static website (business landing page, portfolio, docs) to GitHub Pages. Covers repo creation, content deployment, and Pages enabling via Git |
+| `github-pr-workflow` | A / 必留 | 凭证/API, GitHub | GitHub PR lifecycle: branch, commit, open, CI, merge. |
+| `github-repo-management` | A / 必留 | 凭证/API, GitHub | Clone/create/fork repos; manage remotes, releases. |
+| `github-trend-daily` | B / 可选 | 网关/消息, GitHub | 发现 GitHub AI Agent 热点，生成小红书风格日报并推送到 Telegram |
+| `godmode` | C / 不默认启用 | 凭证/API, 网关/消息, GitHub, 专用 | Jailbreak LLMs: Parseltongue, GODMODE, ULTRAPLINIAN. |
+| `google-workspace` | B / 可选 | 凭证/API, 网关/消息, GitHub | Gmail, Calendar, Drive, Docs, Sheets via gws CLI or Python. |
+| `heartmula` | C / 不默认启用 | macOS, GitHub, 专用 | HeartMuLa: Suno-like song generation from lyrics + tags. |
+| `hermes-agent` | A / 必留 | 凭证/API, macOS, MCP, 网关/消息, 系统级, GitHub | Configure, extend, or contribute to Hermes Agent. |
+| `hermes-agent-skill-authoring` | A / 必留 | 凭证/API, GitHub | Author in-repo SKILL.md: frontmatter, validator, structure. |
+| `hermes-telegram-setup` | A / 必留 | 凭证/API, 网关/消息, GitHub | Set up and troubleshoot Telegram bot integration with Hermes Agent gateway — token config, pairing flow, gateway service management, and common pitfalls. |
+| `himalaya` | B / 可选 | 凭证/API, macOS, GitHub | Himalaya CLI: IMAP/SMTP email from terminal. |
+| `huggingface-hub` | B / 可选 | 凭证/API, GitHub | HuggingFace hf CLI: search/download/upload models, datasets. |
+| `humanizer` | B / 可选 | GitHub | Humanize text: strip AI-isms and add real voice. |
+| `imessage` | C / 不默认启用 | macOS, 网关/消息, 专用 | Send and receive iMessages/SMS via the imsg CLI on macOS. |
+| `inference` | B / 可选 | GitHub | Model serving, quantization (GGUF/GPTQ), structured output, inference optimization, and model surgery tools for deploying and running LLMs. |
+| `jupyter-live-kernel` | B / 可选 | 凭证/API, GitHub | Iterative Python via live Jupyter kernel (hamelnb). |
+| `kanban-orchestrator` | C / 不默认启用 | 凭证/API, 网关/消息, GitHub | Decomposition playbook + specialist-roster conventions + anti-temptation rules for an orchestrator profile routing work through Kanban. The "don't do the work y |
+| `kanban-worker` | C / 不默认启用 | 凭证/API, 网关/消息 | Pitfalls, examples, and edge cases for Hermes Kanban workers. The lifecycle itself is auto-injected into every worker's system prompt as KANBAN_GUIDANCE (from a |
+| `linear` | B / 可选 | 凭证/API, MCP | Linear: manage issues, projects, teams via GraphQL + curl. |
+| `llm-wiki` | B / 可选 | 凭证/API, 系统级, GitHub | Karpathy's LLM Wiki: build/query interlinked markdown KB. |
+| `mails` | B / 可选 | 凭证/API | Email infrastructure for AI agents - send/receive emails via Mails.dev |
+| `manim-video` | B / 可选 | macOS, GitHub | Manim CE animations: 3Blue1Brown math/algo videos. |
+| `maps` | B / 可选 | 网关/消息 | Geocode, POIs, routes, timezones via OpenStreetMap/OSRM. |
+| `matplotlib-charts` | A / 必留 | 凭证/API, macOS, GitHub | 使用 matplotlib 生成图表 - 趋势图、柱状图、饼图、热力图等。导出 PNG/SVG/PDF，用于报告和可视化。 |
+| `minecraft-modpack-server` | C / 不默认启用 | 凭证/API, 系统级, 专用 | Host modded Minecraft servers (CurseForge, Modrinth). |
+| `model-fallback` | A / 必留 | 凭证/API, macOS, GitHub | 为 Hermes Agent 配置模型故障转移，自动切换到备用模型。类似于 FreeRide 的"速率限制自动切换"概念，但专为 Hermes Agent 设计。 |
+| `models` | B / 可选 | - | Specific model architectures and tools — image segmentation (SAM), audio generation (MusicGen), CLIP, Stable Diffusion, Whisper, LLaVA. |
+| `nano-pdf` | B / 可选 | - | Edit PDF text/typos/titles via nano-pdf CLI (NL prompts). |
+| `native-mcp` | A / 必留 | 凭证/API, MCP, 网关/消息, GitHub | MCP client: connect servers, register tools (stdio/HTTP). |
+| `node-inspect-debugger` | A / 必留 | 网关/消息, GitHub | Debug Node.js via --inspect + Chrome DevTools Protocol CLI. |
+| `notion` | B / 可选 | 凭证/API, GitHub | Notion API via curl: pages, databases, blocks, search. |
+| `npm-publishing` | C / 不默认启用 | 凭证/API, 专用 | 发布 npm 包到 npmjs.com。包含认证、权限、发布流程。 |
+| `obsidian` | B / 可选 | 凭证/API, GitHub | Read, search, and create notes in the Obsidian vault. 支持 Hermes-Wiki 知识库工作流。 |
+| `ocr-and-documents` | B / 可选 | GitHub | Extract text from PDFs/scans (pymupdf, marker-pdf). |
+| `opencode` | A / 必留 | 凭证/API, GitHub | Delegate coding to OpenCode CLI (features, PR review). |
+| `openhue` | C / 不默认启用 | macOS, GitHub, 专用 | Control Philips Hue lights, scenes, rooms via OpenHue CLI. |
+| `p5js` | B / 可选 | macOS, GitHub | p5.js sketches: gen art, shaders, interactive, 3D. |
+| `pixel-art` | C / 不默认启用 | macOS, GitHub, 专用 | Pixel art w/ era palettes (NES, Game Boy, PICO-8). |
+| `plan` | A / 必留 | - | Plan mode: write markdown plan to .hermes/plans/, no exec. |
+| `pokemon-player` | C / 不默认启用 | GitHub, 专用 | Play Pokemon via headless emulator + RAM reads. |
+| `polymarket` | B / 可选 | 凭证/API | Query Polymarket: markets, prices, orderbooks, history. |
+| `popular-web-designs` | B / 可选 | 凭证/API, macOS | 54 real design systems (Stripe, Linear, Vercel) as HTML/CSS. |
+| `powerpoint` | B / 可选 | MCP, GitHub | Create, read, edit .pptx decks, slides, notes, templates. |
+| `pretext` | B / 可选 | macOS, GitHub | Use when building creative browser demos with @chenglou/pretext — DOM-free text layout for ASCII art, typographic flow around obstacles, text-as-geometry games, |
+| `public-api-tools` | B / 可选 | GitHub | 来自 public-apis 项目的免费公共 API 工具集 — QR码、图标、截图、LaTeX公式渲染等 |
+| `python-debugpy` | A / 必留 | 凭证/API, 网关/消息, 系统级, GitHub | Debug Python: pdb REPL + debugpy remote (DAP). |
+| `report-generation` | A / 必留 | 凭证/API, macOS, MCP, 网关/消息, GitHub | 生成结构化报告 - Markdown/HTML/PDF 格式的聚合报告、趋势分析、数据摘要。支持定时生成和推送。 |
+| `requesting-code-review` | A / 必留 | 凭证/API, GitHub | Pre-commit review: security scan, quality gates, auto-fix. |
+| `research` | B / 可选 | - | ML research frameworks for building and optimizing AI systems with declarative programming. |
+| `research-paper-writing` | B / 可选 | 凭证/API, macOS, MCP, 系统级, GitHub | Write ML papers for NeurIPS/ICML/ICLR: design→submit. |
+| `scrapling` | B / 可选 | 凭证/API, macOS, MCP, GitHub | Scrapling - 自适应 Web 爬虫框架，支持反爬绕过、自动元素定位、MCP 集成。47k+ stars 的生产级爬虫库。 |
+| `seo-verify` | B / 可选 | 凭证/API, GitHub | Search engine site verification (Google, Baidu, Bing) + sitemap optimization + domain binding workflow. Covers GitHub Pages, Windows shared hosting with FTP, an |
+| `sketch` | B / 可选 | 凭证/API, macOS, GitHub | Throwaway HTML mockups: 2-3 design variants to compare. |
+| `songsee` | C / 不默认启用 | GitHub, 专用 | Audio spectrograms/features (mel, chroma, MFCC) via CLI. |
+| `songwriting-and-ai-music` | C / 不默认启用 | GitHub, 专用 | Songwriting craft and Suno AI music prompts. |
+| `spike` | A / 必留 | 凭证/API, MCP, GitHub | Throwaway experiments to validate an idea before build. |
+| `spotify` | C / 不默认启用 | 凭证/API, GitHub, 专用 | Spotify: play, search, queue, manage playlists and devices. |
+| `sqlite-data` | A / 必留 | 凭证/API, macOS, GitHub | SQLite 数据库操作 - 创建/查询/聚合 Hermes Agent 的结构化数据。存储新闻聚合、趋势数据、任务状态等。 |
+| `subagent-driven-development` | A / 必留 | 凭证/API, GitHub | Execute plans via delegate_task subagents (2-stage review). |
+| `systematic-debugging` | A / 必留 | GitHub | 4-phase root cause debugging: understand bugs before fixing. |
+| `test-driven-development` | A / 必留 | GitHub | TDD: enforce RED-GREEN-REFACTOR, tests before code. |
+| `touchdesigner-mcp` | C / 不默认启用 | macOS, MCP, GitHub, 专用 | Control a running TouchDesigner instance via twozero MCP — create operators, set parameters, wire connections, execute Python, build real-time visuals. 36 nativ |
+| `training` | B / 可选 | - | Fine-tuning, RLHF/DPO/GRPO training, distributed training frameworks, and optimization tools for training LLMs. |
+| `trendradar` | B / 可选 | MCP, 网关/消息, GitHub | TrendRadar trend monitoring and Telegram push — trigger crawl, fetch news, categorize, send multi-message Telegram notifications, archive to Obsidian, sync to G |
+| `trendradar-daily` | B / 可选 | MCP, 网关/消息, GitHub | TrendRadar 多平台热点监控日报生成与 Telegram 推送 |
+| `vector-databases` | B / 可选 | - | Vector database tools and integrations for semantic search and RAG applications. |
+| `webhook-subscriptions` | A / 必留 | 凭证/API, 网关/消息, 系统级, GitHub | Webhook subscriptions: event-driven agent runs. |
+| `website-seo` | B / 可选 | 凭证/API, 网关/消息, 系统级, GitHub | Domain binding, SSL setup, Cloudflare DNS, search engine submission, sitemap management, and Windows shared hosting FTP workflows |
+| `writing-plans` | A / 必留 | - | Write implementation plans: bite-sized tasks, paths, code. |
+| `xurl` | B / 可选 | 凭证/API, macOS, 系统级, GitHub | X/Twitter via xurl CLI: post, search, DM, media, v2 API. |
+| `youtube-content` | B / 可选 | GitHub | YouTube transcripts to summaries, threads, blogs. |
+
+## 安装策略草案
+
+如果后续要改 `scripts/install.sh`，建议支持三种模式：
+
+```bash
+bash scripts/install.sh --core      # 只装 A 档
+bash scripts/install.sh --standard  # A + B，默认推荐
+bash scripts/install.sh --full      # 全量 101 个
+```
+
+默认建议用 `--standard`，不要默认塞入强个人化和风险类技能。

--- a/docs/guides/index.md
+++ b/docs/guides/index.md
@@ -2,23 +2,27 @@
 
 Detailed guides for Hermès Agent features.
 
-## Core Features
+## Available References
 
-- [Memory Management](./memory-management.md) - Understanding the 4-layer memory system
-- [Skills Library](./skills-library.md) - Browse and use 60+ built-in skills
-- [Notifications](./notifications.md) - Configure push notifications
+- [Skills Index](../skills.md) — browse the skill catalog
+- [Architecture Patterns](../evolution/architecture-patterns.md) — reusable AI agent design patterns
+- [Technical Discoveries](../evolution/tech-discoveries.md) — experiments and implementation notes
+- [TrendRadar Discoveries](../projects/discovered-projects.md) — projects and patterns found during exploration
+- [Metrics](../metrics/index.md) — performance tracking and status summaries
 
-## Integrations
+## Planned Guides
 
-- [GitHub Integration](./github-integration.md) - Automate repository tasks
-- [Telegram Bot](./telegram-bot.md) - Master the Telegram interface
-- [HuggingFace](./huggingface.md) - Use models and datasets
+These guides are referenced in the index but not written yet:
 
-## Operations
-
-- [Cron Jobs](./cron-jobs.md) - Schedule recurring tasks
-- [Self-Improvement](./self-improvement.md) - AI-powered growth
-- [Backup System](./backup-system.md) - Protect your data
+- Memory Management
+- Skills Library
+- Notifications
+- GitHub Integration
+- Telegram Bot
+- HuggingFace
+- Cron Jobs
+- Self-Improvement
+- Backup System
 
 ---
 

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -1,5 +1,15 @@
 # 技能索引
 
+Harmes-House 当前包含 101 个技能。默认安装只启用推荐的 A+B 档，避免把强场景/个人化/C 档技能全部塞进 Hermes。
+
+```bash
+bash scripts/install.sh --core      # A 档核心，32 个
+bash scripts/install.sh --standard  # A+B 推荐，78 个，默认
+bash scripts/install.sh --full      # 全量，101 个
+```
+
+完整分级见 [SKILLS_AUDIT.md](SKILLS_AUDIT.md)。
+
 ## devops
 
 | 技能 | 描述 | 状态 |

--- a/docs/tutorials/getting-started.md
+++ b/docs/tutorials/getting-started.md
@@ -1,62 +1,74 @@
 # Quick Start Guide
 
-Get Hermès Agent running in 5 minutes.
+Get Hermès Agent + the Harmes-House skill pack running in 5 minutes.
 
 ## Prerequisites
 
-- Node.js 22.x
-- npm 10.x
-- Telegram account
-- GitHub account (for integrations)
+- Hermes Agent CLI
+- Git + Bash
+- Telegram account (optional)
+- GitHub account / PAT (optional, for integrations)
+- Node.js 22.x only for `projects/*` sub-projects
 
 ## Step 1: Installation
 
 ```bash
-# Clone the repository
+# Install Hermes Agent core
+curl -fsSL https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.sh | bash
+
+# Clone the Harmes-House skill/evolution hub
 git clone https://github.com/clowlove/Harmes-House.git
 cd Harmes-House
 
-# Install dependencies
-npm install
+# Install recommended A+B skills into the active Hermes home
+bash scripts/install.sh
+
+# Optional install modes:
+# bash scripts/install.sh --core      # 32 core skills
+# bash scripts/install.sh --standard  # 78 recommended skills (default)
+# bash scripts/install.sh --full      # all 101 skills
 ```
 
 ## Step 2: Configuration
 
 ```bash
-# Copy environment template
+# Copy environment template when using Telegram / GitHub integrations
 cp .env.example .env
 
 # Edit with your API keys
 nano .env
 ```
 
-Required environment variables:
+Common environment variables:
 - `ANTHROPIC_API_KEY` - Claude API key
 - `TELEGRAM_BOT_TOKEN` - Telegram bot token
 - `GITHUB_TOKEN` - GitHub PAT
+- `OPENROUTER_API_KEY` / `MINIMAX_API_KEY` - optional model providers
 
 ## Step 3: Start
 
 ```bash
-# Run in development
-npm run dev
+# Start Hermes normally
+hermes
 
-# Or run in production
-npm start
+# Or preload one or more installed skills
+hermes -s hermes-agent,github-pr-workflow
 ```
 
 ## Step 4: Verify
 
-1. Open Telegram
-2. Send `/start` to your bot
-3. You should receive a welcome message
+```bash
+hermes skills list
+```
+
+You should see Harmes-House skills available from your Hermes installation.
 
 ## What's Next?
 
-- [Create your first skill](../tutorials/first-skill.md)
-- [Set up TrendRadar](../tutorials/trendradar-guide.md)
-- [Configure notifications](../guides/notifications.md)
+- [Browse available skills](../skills.md)
+- [Read the architecture patterns](../evolution/architecture-patterns.md)
+- [Review the evolution log](../evolution/log-2026-05.md)
 
 ---
 
-*Stuck? Check [Troubleshooting](./troubleshooting.md) or ask on Telegram.*
+*Stuck? Run `hermes doctor` first, then check the repository issues or ask on Telegram.*

--- a/docs/tutorials/index.md
+++ b/docs/tutorials/index.md
@@ -1,24 +1,26 @@
 # Tutorials
 
-Collection of step-by-step guides for using Hermès Agent.
+Collection of step-by-step guides for using Hermès Agent and Harmes-House.
 
-## Getting Started
+## Available
 
-1. [Quick Start Guide](./getting-started.md) - Set up your first agent
-2. [First Skill](./first-skill.md) - Create your first skill
-3. [Memory System](./memory-system.md) - Understand the 4-layer memory
+1. [Quick Start Guide](./getting-started.md) — install Hermes Agent and sync the Harmes-House skill pack
+2. [Skills Index](../skills.md) — browse the available skills
+3. [Architecture Patterns](../evolution/architecture-patterns.md) — understand the agent patterns used by the project
+4. [Evolution Log](../evolution/log-2026-05.md) — follow the project growth history
 
-## Intermediate
+## Planned
 
-4. [Using TrendRadar](./trendradar-guide.md) - Master news aggregation
-5. [GitHub Automation](./github-automation.md) - Automate repo management
-6. [Cron Jobs](./cron-jobs.md) - Schedule recurring tasks
+These tutorials are planned but not written yet:
 
-## Advanced
-
-7. [Multi-Agent Architecture](./multi-agent.md) - Design agent systems
-8. [Custom MCP Integration](./mcp-integration.md) - Extend capabilities
-9. [Performance Optimization](./optimization.md) - Fine-tune your agent
+- Create your first skill
+- Set up TrendRadar
+- Configure notifications
+- GitHub automation
+- Cron jobs
+- Multi-agent architecture
+- Custom MCP integration
+- Performance optimization
 
 ---
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,40 +1,285 @@
-#!/bin/bash
-# Hermes House 安装脚本
+#!/usr/bin/env bash
+# Hermes House installer
+#
+# Installs the Harmes-House skill pack into the active Hermes home.
+# Prefer HERMES_HOME over HOME/.hermes because embedded runtimes such as
+# Hermes WebUI may sandbox HOME while the active config lives under HERMES_HOME.
 
-set -e
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+SOURCE_SKILLS="$REPO_ROOT/skills"
+HERMES_HOME_PATH="${HERMES_HOME:-$HOME/.hermes}"
+TARGET_ROOT=""
+MODE="standard"
+
+print_usage() {
+  cat <<'USAGE'
+🏠 Hermes House 安装程序
+
+用法：
+  bash scripts/install.sh [--core|--standard|--full] [--target PATH]
+  bash scripts/install.sh [--core|--standard|--full] [PATH]
+
+模式：
+  --core      只安装 A 档核心技能（32 个）
+  --standard  安装 A+B 档推荐技能（78 个，默认）
+  --full      安装全部技能（101 个，含强场景/个人化/C 档）
+
+示例：
+  bash scripts/install.sh
+  bash scripts/install.sh --core
+  bash scripts/install.sh --full --target "$HERMES_HOME/skills/harmes-house"
+USAGE
+}
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --core)
+      MODE="core"
+      shift
+      ;;
+    --standard)
+      MODE="standard"
+      shift
+      ;;
+    --full)
+      MODE="full"
+      shift
+      ;;
+    -t|--target)
+      if [ "$#" -lt 2 ]; then
+        echo "❌ --target 需要路径参数。"
+        exit 1
+      fi
+      TARGET_ROOT="$2"
+      shift 2
+      ;;
+    -h|--help)
+      print_usage
+      exit 0
+      ;;
+    --*)
+      echo "❌ 未知参数: $1"
+      print_usage
+      exit 1
+      ;;
+    *)
+      if [ -n "$TARGET_ROOT" ]; then
+        echo "❌ 只能指定一个安装目标路径。"
+        exit 1
+      fi
+      TARGET_ROOT="$1"
+      shift
+      ;;
+  esac
+done
+
+TARGET_ROOT="${TARGET_ROOT:-$HERMES_HOME_PATH/skills/harmes-house}"
+
+CORE_SKILLS=(
+  'claude-code'
+  'cli-utilities'
+  'codebase-inspection'
+  'codex'
+  'copilot-cli'
+  'custom-openai-provider'
+  'debugging-hermes-tui-commands'
+  'github-auth'
+  'github-code-review'
+  'github-issues'
+  'github-pages-site'
+  'github-pr-workflow'
+  'github-repo-management'
+  'hermes-agent'
+  'hermes-agent-skill-authoring'
+  'hermes-telegram-setup'
+  'matplotlib-charts'
+  'model-fallback'
+  'native-mcp'
+  'node-inspect-debugger'
+  'opencode'
+  'plan'
+  'python-debugpy'
+  'report-generation'
+  'requesting-code-review'
+  'spike'
+  'sqlite-data'
+  'subagent-driven-development'
+  'systematic-debugging'
+  'test-driven-development'
+  'webhook-subscriptions'
+  'writing-plans'
+)
+
+OPTIONAL_SKILLS=(
+  'airtable'
+  'architecture-diagram'
+  'arxiv'
+  'baoyu-comic'
+  'baoyu-infographic'
+  'blogwatcher'
+  'claude-design'
+  'comfyui'
+  'design-md'
+  'evaluation'
+  'excalidraw'
+  'github-trend-daily'
+  'google-workspace'
+  'himalaya'
+  'huggingface-hub'
+  'humanizer'
+  'inference'
+  'jupyter-live-kernel'
+  'linear'
+  'llm-wiki'
+  'mails'
+  'manim-video'
+  'maps'
+  'models'
+  'nano-pdf'
+  'notion'
+  'obsidian'
+  'ocr-and-documents'
+  'p5js'
+  'polymarket'
+  'popular-web-designs'
+  'powerpoint'
+  'pretext'
+  'public-api-tools'
+  'research'
+  'research-paper-writing'
+  'scrapling'
+  'seo-verify'
+  'sketch'
+  'training'
+  'trendradar'
+  'trendradar-daily'
+  'vector-databases'
+  'website-seo'
+  'xurl'
+  'youtube-content'
+)
+
+EXTRA_SKILLS=(
+  '3x-ui'
+  'apple-notes'
+  'apple-reminders'
+  'ascii-art'
+  'ascii-video'
+  'creative-ideation'
+  'findmy'
+  'foreign-trade-operations'
+  'gif-search'
+  'godmode'
+  'heartmula'
+  'imessage'
+  'kanban-orchestrator'
+  'kanban-worker'
+  'minecraft-modpack-server'
+  'npm-publishing'
+  'openhue'
+  'pixel-art'
+  'pokemon-player'
+  'songsee'
+  'songwriting-and-ai-music'
+  'spotify'
+  'touchdesigner-mcp'
+)
+
+case "$MODE" in
+  core)
+    INSTALL_SKILLS=("${CORE_SKILLS[@]}")
+    MODE_LABEL="A 档核心"
+    ;;
+  standard)
+    INSTALL_SKILLS=("${CORE_SKILLS[@]}" "${OPTIONAL_SKILLS[@]}")
+    MODE_LABEL="A+B 档推荐"
+    ;;
+  full)
+    INSTALL_SKILLS=("${CORE_SKILLS[@]}" "${OPTIONAL_SKILLS[@]}" "${EXTRA_SKILLS[@]}")
+    MODE_LABEL="全量"
+    ;;
+  *)
+    echo "❌ 无效安装模式: $MODE"
+    exit 1
+    ;;
+esac
+ALL_KNOWN_SKILLS=("${CORE_SKILLS[@]}" "${OPTIONAL_SKILLS[@]}" "${EXTRA_SKILLS[@]}")
+
+if [ ! -d "$SOURCE_SKILLS" ]; then
+  echo "❌ 未找到 skills 目录，请确保仓库完整。"
+  exit 1
+fi
+
+if ! command -v hermes >/dev/null 2>&1; then
+  echo "⚠️  未检测到 hermes 命令。"
+  echo "先安装 Hermes Agent："
+  echo "  curl -fsSL https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.sh | bash"
+  echo "然后重新运行："
+  echo "  bash scripts/install.sh"
+  exit 1
+fi
+
+missing=0
+for skill in "${INSTALL_SKILLS[@]}"; do
+  if [ ! -d "$SOURCE_SKILLS/$skill" ]; then
+    echo "❌ 缺少技能目录: $SOURCE_SKILLS/$skill"
+    missing=1
+  fi
+done
+if [ "$missing" -ne 0 ]; then
+  exit 1
+fi
+
+CONFIG_PATH="$(hermes config path 2>/dev/null || true)"
 
 echo "🏠 Hermes House 安装程序"
 echo "========================="
+echo "仓库目录: $REPO_ROOT"
+echo "Hermes Home: $HERMES_HOME_PATH"
+if [ -n "$CONFIG_PATH" ]; then
+  echo "Hermes 配置: $CONFIG_PATH"
+fi
+echo "技能来源: $SOURCE_SKILLS"
+echo "安装目标: $TARGET_ROOT"
+echo "安装模式: $MODE ($MODE_LABEL, ${#INSTALL_SKILLS[@]} 个技能)"
+echo ""
 
-# 检测操作系统
-OS=$(uname -s)
-echo "检测到系统: $OS"
+echo "📦 同步技能..."
+mkdir -p "$TARGET_ROOT"
 
-# 安装目录
-HERMES_SKILLS="$HOME/.hermes/skills"
+# Remove only known Harmes-House skill directories so switching from --full to
+# --standard/--core does not leave stale C/B skills behind, while unrelated
+# files in a custom target directory are preserved.
+for skill in "${ALL_KNOWN_SKILLS[@]}"; do
+  rm -rf "$TARGET_ROOT/$skill"
+done
 
-# 创建目录
-mkdir -p "$HERMES_SKILLS/devops"
+for skill in "${INSTALL_SKILLS[@]}"; do
+  cp -R "$SOURCE_SKILLS/$skill" "$TARGET_ROOT/"
+done
 
-# 复制技能
-echo "📦 安装技能..."
+installed_count=0
+for skill in "${INSTALL_SKILLS[@]}"; do
+  if [ -d "$TARGET_ROOT/$skill" ]; then
+    installed_count=$((installed_count + 1))
+  fi
+done
 
-if [ -d "skills" ]; then
-    cp -r skills/* "$HERMES_SKILLS/devops/"
-    echo "✅ 技能已安装到 $HERMES_SKILLS/devops/"
-else
-    echo "❌ 未找到 skills 目录，请确保在仓库根目录运行此脚本"
-    exit 1
+if [ "$installed_count" -ne "${#INSTALL_SKILLS[@]}" ]; then
+  echo "❌ 安装数量不一致：期望 ${#INSTALL_SKILLS[@]}，实际 $installed_count"
+  exit 1
 fi
 
-# 验证安装
+echo "✅ 已同步 $installed_count 个技能到 $TARGET_ROOT"
 echo ""
-echo "📋 已安装技能:"
-ls -la "$HERMES_SKILLS/devops/"
-
+echo "🔍 验证："
+echo "  hermes skills list"
+echo "  hermes -s harmes-house/hermes-agent"
 echo ""
-echo "🎉 安装完成！"
-echo ""
-echo "使用示例："
-echo "  hermes skills list    # 查看已安装技能"
-echo "  hermes skills enable <skill-name>  # 启用技能"
+echo "💡 下一步："
+echo "  1. 在当前 Hermes 会话输入 /reset，或重新启动 hermes，让新技能生效。"
+echo "  2. 默认 --standard 不安装 C 档；需要全量时运行 bash scripts/install.sh --full。"
+echo "  3. 需要 Telegram / GitHub 集成时，复制 .env.example 并填入自己的密钥。"


### PR DESCRIPTION
## Summary
- Add a tiered Harmes-House skill installer flow for Hermes users
- Support safer incremental install/update behavior instead of one large manual copy
- Document defaults and verification points for users following the NodeSeek/Harmes-House setup path

## Test Plan
- Local script/metadata checks passed before commit
- Git push to fork verified
