### PR TITLE
fix: add missing skill.json for 5 skills (Validate CI)

### DIFF
--- a/docs/evolution/log-2026-05.md
+++ b/docs/evolution/log-2026-05.md
@@ -1228,6 +1228,30 @@
 
 ---
 
+
+### 2026-05-27 — 社区探索
+
+**发现的新项目：**
+
+- **WebRover** (994⭐): WebRover is an autonomous AI agent designed to interpret user input and execute actions by interacting with web elements to accomplish tasks or answer questions. It leverages advanced language models and web automation tools to navigate the web, gather information, and provide structured responses based on the user's needs.
+  - URL: https://github.com/hrithikkoduri/WebRover
+- **airecon** (629⭐): AIRecon is an autonomous cybersecurity agent that combines a self-hosted Large Language Model (Ollama) with a Kali Linux Docker sandbox and a Textual TUI. It is designed to automate security assessments, penetration testing, and bug bounty reconnaissance — without any API keys or cloud dependency.
+  - URL: https://github.com/pikpikcu/airecon
+- **gemini-youtube-automation** (276⭐): A fully autonomous AI Agent/Python pipeline that utilizes Large Language Models (LLMs) like Gemini to generate content, produce videos, and automatically upload educational videos to YouTube.
+  - URL: https://github.com/ChaitanyaEswarRajeshJakki/gemini-youtube-automation
+- **mcp-agent** (8342⭐): Build effective agents using Model Context Protocol and simple workflow patterns
+  - URL: https://github.com/lastmile-ai/mcp-agent
+- **XcodeBuildMCP** (5749⭐): A Model Context Protocol (MCP) server and CLI that provides tools for agent use when working on iOS and macOS projects.
+  - URL: https://github.com/getsentry/XcodeBuildMCP
+- **mobile-mcp** (5042⭐): Model Context Protocol Server for Mobile Automation and Scraping (iOS, Android, Emulators, Simulators and Real Devices)
+  - URL: https://github.com/mobile-next/mobile-mcp
+- **EasyInstruct** (406⭐): [ACL 2024] An Easy-to-use Instruction Processing Framework for LLMs.
+  - URL: https://github.com/zjunlp/EasyInstruct
+- **ARM-Thinker** (186⭐): [CVPR 2026] Official Code for "ARM-Thinker: Reinforcing Multimodal Generative Reward Models with Agentic Tool Use and Visual Reasoning"
+  - URL: https://github.com/InternLM/ARM-Thinker
+
+---
+
 ---
 
 *日志自动生成，最后更新: 2026-05-05*

--- a/skills/geo-optimizer/skill.json
+++ b/skills/geo-optimizer/skill.json
@@ -1,0 +1,5 @@
+{
+  "name": "geo-optimizer",
+  "version": "1.0.0",
+  "description": "Optimize content for AI search engines (ChatGPT, Perplexity, Gemini, AI Overviews) — Generative Engine Optimization"
+}

--- a/skills/keyword-research/skill.json
+++ b/skills/keyword-research/skill.json
@@ -1,0 +1,5 @@
+{
+  "name": "keyword-research",
+  "version": "1.0.0",
+  "description": "Discover, analyze, and prioritize keywords for SEO and GEO content strategies"
+}

--- a/skills/meta-tags-optimizer/skill.json
+++ b/skills/meta-tags-optimizer/skill.json
@@ -1,0 +1,5 @@
+{
+  "name": "meta-tags-optimizer",
+  "version": "1.0.0",
+  "description": "Optimize title tags, meta descriptions, Open Graph, and Twitter cards for maximum click-through rate"
+}

--- a/skills/schema-markup-generator/skill.json
+++ b/skills/schema-markup-generator/skill.json
@@ -1,0 +1,5 @@
+{
+  "name": "schema-markup-generator",
+  "version": "1.0.0",
+  "description": "Generate JSON-LD structured data for rich snippets and AI search enhancement"
+}

--- a/skills/seo-analysis/skill.json
+++ b/skills/seo-analysis/skill.json
@@ -1,0 +1,5 @@
+{
+  "name": "seo-analysis",
+  "version": "1.0.0",
+  "description": "Full SEO audit: analyze keywords, meta tags, content quality, technical SEO, and competitor positioning"
+}


### PR DESCRIPTION
## Problem
The 'Validate Skills' CI workflow was failing because 5 skills were missing required `skill.json` files.

## Fix
Added `skill.json` with required fields (name, version, description) for:
- `geo-optimizer`
- `keyword-research`
- `meta-tags-optimizer`
- `schema-markup-generator`
- `seo-analysis`

All 5 files follow the same schema as existing skills in the repo.

## Verification
Run the Validate Skills workflow — all skills should now pass ✅