### PR TITLE
fix: correct SPDX license identifiers in Security & Quality workflow

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -14,6 +14,8 @@ jobs:
       security-events: write
       actions: read
       contents: read
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
 
     steps:
     - name: Checkout repository
@@ -32,6 +34,8 @@ jobs:
   dependency-review:
     name: Dependency Review
     runs-on: ubuntu-latest
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4
@@ -43,12 +47,16 @@ jobs:
         deny-packages: |
           # Packages to deny
         deny-licenses: |
-          GPL-3.0
-          AGPL-3.0
+          GPL-3.0-only
+          GPL-3.0-or-later
+          AGPL-3.0-only
+          AGPL-3.0-or-later
 
   secscan:
     name: Security Scan
     runs-on: ubuntu-latest
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
     steps:
     - name: Checkout
       uses: actions/checkout@v4


### PR DESCRIPTION
## Problem

The  workflow (run #22) failed with:

> Invalid license(s) in deny-licenses: GPL-3.0 AGPL-3.0

The  expects valid [SPDX license identifiers](https://spdx.org/licenses/), but  and  are not recognized — the correct identifiers are , , , and .

Additionally, Node.js 20 deprecation warnings were shown for .

## Changes

1. **Fix SPDX identifiers** — Replace  →  + ,  →  + 
2. **Address Node.js 20 deprecation** — Add  env to all jobs

Closes the CI failure on commit 7822396.