### PR TITLE
fix: add missing skill.json files for 16 skills

### DIFF
--- a/skills/ai-code-review/skill.json
+++ b/skills/ai-code-review/skill.json
@@ -1,0 +1,24 @@
+{
+  "name": "ai-code-review",
+  "version": "1.0.0",
+  "description": "AI-powered code review with security scanning, performance analysis, and best practices checking.",
+  "author": "Hermes Agent",
+  "license": "MIT",
+  "platforms": [
+    "linux",
+    "macos"
+  ],
+  "commands": [],
+  "tags": "AI, Code-Review, Security, Automation",
+  "hermes": {
+    "skill_category": "general",
+    "compatibility": [
+      "hermes-agent >= 1.0.0"
+    ]
+  },
+  "files": [
+    "SKILL.md"
+  ],
+  "last_updated": "2026-06-05",
+  "status": "stable"
+}

--- a/skills/ai-translator/skill.json
+++ b/skills/ai-translator/skill.json
@@ -1,0 +1,24 @@
+{
+  "name": "ai-translator",
+  "version": "1.0.0",
+  "description": "Advanced AI translation with context awareness, terminology management, and quality scoring.",
+  "author": "Hermes Agent",
+  "license": "MIT",
+  "platforms": [
+    "linux",
+    "macos"
+  ],
+  "commands": [],
+  "tags": "Translation, AI, Localization, NLP",
+  "hermes": {
+    "skill_category": "general",
+    "compatibility": [
+      "hermes-agent >= 1.0.0"
+    ]
+  },
+  "files": [
+    "SKILL.md"
+  ],
+  "last_updated": "2026-06-05",
+  "status": "stable"
+}

--- a/skills/ai-video-generator/skill.json
+++ b/skills/ai-video-generator/skill.json
@@ -1,0 +1,24 @@
+{
+  "name": "ai-video-generator",
+  "version": "1.0.0",
+  "description": "Generate AI videos from text prompts using multiple providers.",
+  "author": "Hermes Agent",
+  "license": "MIT",
+  "platforms": [
+    "linux",
+    "macos"
+  ],
+  "commands": [],
+  "tags": "Video, AI, Generation, Automation",
+  "hermes": {
+    "skill_category": "general",
+    "compatibility": [
+      "hermes-agent >= 1.0.0"
+    ]
+  },
+  "files": [
+    "SKILL.md"
+  ],
+  "last_updated": "2026-06-05",
+  "status": "stable"
+}

--- a/skills/api-doc-generator/skill.json
+++ b/skills/api-doc-generator/skill.json
@@ -1,0 +1,24 @@
+{
+  "name": "api-doc-generator",
+  "version": "1.0.0",
+  "description": "Generate API documentation from code, OpenAPI specs, or raw endpoints.",
+  "author": "Hermes Agent",
+  "license": "MIT",
+  "platforms": [
+    "linux",
+    "macos"
+  ],
+  "commands": [],
+  "tags": "API, Documentation, OpenAPI, Markdown",
+  "hermes": {
+    "skill_category": "general",
+    "compatibility": [
+      "hermes-agent >= 1.0.0"
+    ]
+  },
+  "files": [
+    "SKILL.md"
+  ],
+  "last_updated": "2026-06-05",
+  "status": "stable"
+}

--- a/skills/auto-backup/skill.json
+++ b/skills/auto-backup/skill.json
@@ -1,0 +1,24 @@
+{
+  "name": "auto-backup",
+  "version": "1.0.0",
+  "description": "Automated backup solution for databases, files, and cloud storage.",
+  "author": "Hermes Agent",
+  "license": "MIT",
+  "platforms": [
+    "linux",
+    "macos"
+  ],
+  "commands": [],
+  "tags": "Backup, Automation, Cloud, Database",
+  "hermes": {
+    "skill_category": "general",
+    "compatibility": [
+      "hermes-agent >= 1.0.0"
+    ]
+  },
+  "files": [
+    "SKILL.md"
+  ],
+  "last_updated": "2026-06-05",
+  "status": "stable"
+}

--- a/skills/auto-deploy/skill.json
+++ b/skills/auto-deploy/skill.json
@@ -1,0 +1,24 @@
+{
+  "name": "auto-deploy",
+  "version": "1.0.0",
+  "description": "One-click deployment to multiple platforms with CI/CD setup.",
+  "author": "Hermes Agent",
+  "license": "MIT",
+  "platforms": [
+    "linux",
+    "macos"
+  ],
+  "commands": [],
+  "tags": "Deployment, CI/CD, DevOps, Automation",
+  "hermes": {
+    "skill_category": "general",
+    "compatibility": [
+      "hermes-agent >= 1.0.0"
+    ]
+  },
+  "files": [
+    "SKILL.md"
+  ],
+  "last_updated": "2026-06-05",
+  "status": "stable"
+}

--- a/skills/coding-assistant/skill.json
+++ b/skills/coding-assistant/skill.json
@@ -1,0 +1,24 @@
+{
+  "name": "coding-assistant",
+  "version": "1.0.0",
+  "description": "AI-powered coding assistant for code generation, debugging, and refactoring.",
+  "author": "Hermes Agent",
+  "license": "MIT",
+  "platforms": [
+    "linux",
+    "macos"
+  ],
+  "commands": [],
+  "tags": "AI, Coding, Assistant, Automation",
+  "hermes": {
+    "skill_category": "general",
+    "compatibility": [
+      "hermes-agent >= 1.0.0"
+    ]
+  },
+  "files": [
+    "SKILL.md"
+  ],
+  "last_updated": "2026-06-05",
+  "status": "stable"
+}

--- a/skills/content-generator/skill.json
+++ b/skills/content-generator/skill.json
@@ -1,0 +1,24 @@
+{
+  "name": "content-generator",
+  "version": "1.0.0",
+  "description": "AI content generation for blogs, social media, and marketing copy.",
+  "author": "Hermes Agent",
+  "license": "MIT",
+  "platforms": [
+    "linux",
+    "macos"
+  ],
+  "commands": [],
+  "tags": "Content, AI, Marketing, Social-Media",
+  "hermes": {
+    "skill_category": "general",
+    "compatibility": [
+      "hermes-agent >= 1.0.0"
+    ]
+  },
+  "files": [
+    "SKILL.md"
+  ],
+  "last_updated": "2026-06-05",
+  "status": "stable"
+}

--- a/skills/data-scraper/skill.json
+++ b/skills/data-scraper/skill.json
@@ -1,0 +1,24 @@
+{
+  "name": "data-scraper",
+  "version": "1.0.0",
+  "description": "Extract data from websites, APIs, and files with anti-bot evasion.",
+  "author": "Hermes Agent",
+  "license": "MIT",
+  "platforms": [
+    "linux",
+    "macos"
+  ],
+  "commands": [],
+  "tags": "Scraper, Data, Web, API, Automation",
+  "hermes": {
+    "skill_category": "general",
+    "compatibility": [
+      "hermes-agent >= 1.0.0"
+    ]
+  },
+  "files": [
+    "SKILL.md"
+  ],
+  "last_updated": "2026-06-05",
+  "status": "stable"
+}

--- a/skills/github-star-bot/skill.json
+++ b/skills/github-star-bot/skill.json
@@ -1,0 +1,24 @@
+{
+  "name": "github-star-bot",
+  "version": "1.0.0",
+  "description": "Automate GitHub starring, tracking repositories, and managing star-based alerts.",
+  "author": "Hermes Agent",
+  "license": "MIT",
+  "platforms": [
+    "linux",
+    "macos"
+  ],
+  "commands": [],
+  "tags": "GitHub, Bot, Automation, Stars",
+  "hermes": {
+    "skill_category": "general",
+    "compatibility": [
+      "hermes-agent >= 1.0.0"
+    ]
+  },
+  "files": [
+    "SKILL.md"
+  ],
+  "last_updated": "2026-06-05",
+  "status": "stable"
+}

--- a/skills/price-tracker/skill.json
+++ b/skills/price-tracker/skill.json
@@ -1,0 +1,24 @@
+{
+  "name": "price-tracker",
+  "version": "1.0.0",
+  "description": "Track product prices across multiple platforms and get alerts when prices drop.",
+  "author": "Hermes Agent",
+  "license": "MIT",
+  "platforms": [
+    "linux",
+    "macos"
+  ],
+  "commands": [],
+  "tags": "Price, Tracker, E-commerce, Automation",
+  "hermes": {
+    "skill_category": "general",
+    "compatibility": [
+      "hermes-agent >= 1.0.0"
+    ]
+  },
+  "files": [
+    "SKILL.md"
+  ],
+  "last_updated": "2026-06-05",
+  "status": "stable"
+}

--- a/skills/security-scan/skill.json
+++ b/skills/security-scan/skill.json
@@ -1,0 +1,24 @@
+{
+  "name": "security-scan",
+  "version": "1.0.0",
+  "description": "Comprehensive security scanning for code, dependencies, and infrastructure.",
+  "author": "Hermes Agent",
+  "license": "MIT",
+  "platforms": [
+    "linux",
+    "macos"
+  ],
+  "commands": [],
+  "tags": "Security, Scanner, Vulnerability, CI/CD",
+  "hermes": {
+    "skill_category": "general",
+    "compatibility": [
+      "hermes-agent >= 1.0.0"
+    ]
+  },
+  "files": [
+    "SKILL.md"
+  ],
+  "last_updated": "2026-06-05",
+  "status": "stable"
+}

--- a/skills/smart-analytics/skill.json
+++ b/skills/smart-analytics/skill.json
@@ -1,0 +1,24 @@
+{
+  "name": "smart-analytics",
+  "version": "1.0.0",
+  "description": "Business analytics dashboard with real-time metrics and data visualization.",
+  "author": "Hermes Agent",
+  "license": "MIT",
+  "platforms": [
+    "linux",
+    "macos"
+  ],
+  "commands": [],
+  "tags": "Analytics, Dashboard, Metrics, Business-Intelligence",
+  "hermes": {
+    "skill_category": "general",
+    "compatibility": [
+      "hermes-agent >= 1.0.0"
+    ]
+  },
+  "files": [
+    "SKILL.md"
+  ],
+  "last_updated": "2026-06-05",
+  "status": "stable"
+}

--- a/skills/social-media-auto/skill.json
+++ b/skills/social-media-auto/skill.json
@@ -1,0 +1,24 @@
+{
+  "name": "social-media-auto",
+  "version": "1.0.0",
+  "description": "Unified social media management across multiple platforms.",
+  "author": "Hermes Agent",
+  "license": "MIT",
+  "platforms": [
+    "linux",
+    "macos"
+  ],
+  "commands": [],
+  "tags": "Social-Media, Automation, Twitter, LinkedIn",
+  "hermes": {
+    "skill_category": "general",
+    "compatibility": [
+      "hermes-agent >= 1.0.0"
+    ]
+  },
+  "files": [
+    "SKILL.md"
+  ],
+  "last_updated": "2026-06-05",
+  "status": "stable"
+}

--- a/skills/twitter-bot/skill.json
+++ b/skills/twitter-bot/skill.json
@@ -1,0 +1,24 @@
+{
+  "name": "twitter-bot",
+  "version": "1.0.0",
+  "description": "Automate Twitter/X posting, engagement, and analytics.",
+  "author": "Hermes Agent",
+  "license": "MIT",
+  "platforms": [
+    "linux",
+    "macos"
+  ],
+  "commands": [],
+  "tags": "Twitter, Bot, X, Social-Media, Automation",
+  "hermes": {
+    "skill_category": "general",
+    "compatibility": [
+      "hermes-agent >= 1.0.0"
+    ]
+  },
+  "files": [
+    "SKILL.md"
+  ],
+  "last_updated": "2026-06-05",
+  "status": "stable"
+}

--- a/skills/youtube-auto/skill.json
+++ b/skills/youtube-auto/skill.json
@@ -1,0 +1,24 @@
+{
+  "name": "youtube-auto",
+  "version": "1.0.0",
+  "description": "Automate YouTube content creation, SEO optimization, and channel management.",
+  "author": "Hermes Agent",
+  "license": "MIT",
+  "platforms": [
+    "linux",
+    "macos"
+  ],
+  "commands": [],
+  "tags": "YouTube, SEO, Automation, Content",
+  "hermes": {
+    "skill_category": "general",
+    "compatibility": [
+      "hermes-agent >= 1.0.0"
+    ]
+  },
+  "files": [
+    "SKILL.md"
+  ],
+  "last_updated": "2026-06-05",
+  "status": "stable"
+}


### PR DESCRIPTION
## Summary

Added missing `skill.json` files for 16 skills that were causing the **Validate Skills** CI workflow to fail.

### Skills fixed
- ai-code-review, ai-translator, ai-video-generator, api-doc-generator
- auto-backup, auto-deploy, coding-assistant, content-generator
- data-scraper, github-star-bot, price-tracker, security-scan
- smart-analytics, social-media-auto, twitter-bot, youtube-auto

---
*Generated by Hermes Agent autonomous learning cron*