### PR TITLE
fix: add hermes config to 5 SEO/Marketing skill.json files

### DIFF
--- a/skills/geo-optimizer/skill.json
+++ b/skills/geo-optimizer/skill.json
@@ -1,5 +1,24 @@
 {
   "name": "geo-optimizer",
   "version": "1.0.0",
-  "description": "Optimize content for AI search engines (ChatGPT, Perplexity, Gemini, AI Overviews) — Generative Engine Optimization"
+  "description": "Optimize content for AI search engines (ChatGPT, Perplexity, Gemini, AI Overviews) — Generative Engine Optimization",
+  "author": "agency-agents-zh",
+  "license": "MIT",
+  "platforms": [
+    "linux",
+    "macos"
+  ],
+  "commands": [],
+  "tags": "[marketing]",
+  "hermes": {
+    "skill_category": "marketing",
+    "compatibility": [
+      "hermes-agent >= 1.0.0"
+    ]
+  },
+  "files": [
+    "SKILL.md"
+  ],
+  "last_updated": "2026-05-03",
+  "status": "stable"
 }

--- a/skills/keyword-research/skill.json
+++ b/skills/keyword-research/skill.json
@@ -1,5 +1,24 @@
 {
   "name": "keyword-research",
   "version": "1.0.0",
-  "description": "Discover, analyze, and prioritize keywords for SEO and GEO content strategies"
+  "description": "Discover, analyze, and prioritize keywords for SEO and GEO content strategies",
+  "author": "agency-agents-zh",
+  "license": "MIT",
+  "platforms": [
+    "linux",
+    "macos"
+  ],
+  "commands": [],
+  "tags": "[marketing]",
+  "hermes": {
+    "skill_category": "marketing",
+    "compatibility": [
+      "hermes-agent >= 1.0.0"
+    ]
+  },
+  "files": [
+    "SKILL.md"
+  ],
+  "last_updated": "2026-05-03",
+  "status": "stable"
 }

--- a/skills/meta-tags-optimizer/skill.json
+++ b/skills/meta-tags-optimizer/skill.json
@@ -1,5 +1,24 @@
 {
   "name": "meta-tags-optimizer",
   "version": "1.0.0",
-  "description": "Optimize title tags, meta descriptions, Open Graph, and Twitter cards for maximum click-through rate"
+  "description": "Optimize title tags, meta descriptions, Open Graph, and Twitter cards for maximum click-through rate",
+  "author": "agency-agents-zh",
+  "license": "MIT",
+  "platforms": [
+    "linux",
+    "macos"
+  ],
+  "commands": [],
+  "tags": "[marketing]",
+  "hermes": {
+    "skill_category": "marketing",
+    "compatibility": [
+      "hermes-agent >= 1.0.0"
+    ]
+  },
+  "files": [
+    "SKILL.md"
+  ],
+  "last_updated": "2026-05-03",
+  "status": "stable"
 }

--- a/skills/schema-markup-generator/skill.json
+++ b/skills/schema-markup-generator/skill.json
@@ -1,5 +1,24 @@
 {
   "name": "schema-markup-generator",
   "version": "1.0.0",
-  "description": "Generate JSON-LD structured data for rich snippets and AI search enhancement"
+  "description": "Generate JSON-LD structured data for rich snippets and AI search enhancement",
+  "author": "agency-agents-zh",
+  "license": "MIT",
+  "platforms": [
+    "linux",
+    "macos"
+  ],
+  "commands": [],
+  "tags": "[marketing]",
+  "hermes": {
+    "skill_category": "marketing",
+    "compatibility": [
+      "hermes-agent >= 1.0.0"
+    ]
+  },
+  "files": [
+    "SKILL.md"
+  ],
+  "last_updated": "2026-05-03",
+  "status": "stable"
 }

--- a/skills/seo-analysis/skill.json
+++ b/skills/seo-analysis/skill.json
@@ -1,5 +1,24 @@
 {
   "name": "seo-analysis",
   "version": "1.0.0",
-  "description": "Full SEO audit: analyze keywords, meta tags, content quality, technical SEO, and competitor positioning"
+  "description": "Full SEO audit: analyze keywords, meta tags, content quality, technical SEO, and competitor positioning",
+  "author": "agency-agents-zh",
+  "license": "MIT",
+  "platforms": [
+    "linux",
+    "macos"
+  ],
+  "commands": [],
+  "tags": "[marketing]",
+  "hermes": {
+    "skill_category": "marketing",
+    "compatibility": [
+      "hermes-agent >= 1.0.0"
+    ]
+  },
+  "files": [
+    "SKILL.md"
+  ],
+  "last_updated": "2026-05-03",
+  "status": "stable"
 }


### PR DESCRIPTION
本地验证发现以下 5 个技能的 skill.json 缺少 hermes 配置字段，导致验证失败：

- geo-optimizer
- keyword-research
- meta-tags-optimizer
- schema-markup-generator
- seo-analysis

已补全 hermes.skill_category 及其他标准字段，本地 validate_skills.py 现已全部通过。